### PR TITLE
Feature/10 logout

### DIFF
--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -3,7 +3,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
-import '../../features/auth/presentation/providers/auth_notifier.dart';
+import '../../features/auth/presentation/providers/auth_notifier.dart'
+    show authProvider;
 import '../../features/auth/presentation/screens/login_screen.dart';
 import '../../features/player/presentation/screens/player_screen.dart';
 import '../../features/songs/presentation/screens/songs_screen.dart';
@@ -16,7 +17,8 @@ final appRouter = Provider<GoRouter>((ref) {
     navigatorKey: _routerKey,
     initialLocation: '/songs',
     redirect: (context, state) {
-      final isAuth = ref.read(authProvider);
+      final authState = ref.read(authProvider);
+      final isAuth = authState.isAuthenticated;
       final isOnLogin = state.matchedLocation == '/login';
       final isOnDebug = state.matchedLocation == '/debug';
 

--- a/lib/features/auth/presentation/providers/auth_notifier.dart
+++ b/lib/features/auth/presentation/providers/auth_notifier.dart
@@ -1,3 +1,74 @@
-import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'dart:async';
 
-final authProvider = StateProvider<bool>((ref) => false);
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:supabase_flutter/supabase_flutter.dart' as supabase;
+
+enum AuthStatus { authenticated, unauthenticated, loading }
+
+class AppAuthState {
+  final AuthStatus status;
+  final supabase.User? user;
+
+  const AppAuthState({
+    this.status = AuthStatus.loading,
+    this.user,
+  });
+
+  AppAuthState copyWith({AuthStatus? status, supabase.User? user}) {
+    return AppAuthState(
+      status: status ?? this.status,
+      user: user ?? this.user,
+    );
+  }
+
+  bool get isAuthenticated => status == AuthStatus.authenticated;
+}
+
+final supabaseAuthClientProvider = Provider<supabase.GoTrueClient>((ref) {
+  return supabase.Supabase.instance.client.auth;
+});
+
+class AuthNotifier extends Notifier<AppAuthState> {
+  StreamSubscription? _authSubscription;
+
+  @override
+  AppAuthState build() {
+    final authClient = ref.watch(supabaseAuthClientProvider);
+
+    _authSubscription = authClient.onAuthStateChange.listen((event) {
+      final session = authClient.currentSession;
+      if (session != null) {
+        state = AppAuthState(
+          status: AuthStatus.authenticated,
+          user: session.user,
+        );
+      } else {
+        state = const AppAuthState(status: AuthStatus.unauthenticated);
+      }
+    });
+
+    ref.onDispose(() {
+      _authSubscription?.cancel();
+    });
+
+    final initialSession = authClient.currentSession;
+    if (initialSession != null) {
+      return AppAuthState(
+        status: AuthStatus.authenticated,
+        user: initialSession.user,
+      );
+    }
+
+    return const AppAuthState(status: AuthStatus.unauthenticated);
+  }
+
+  Future<void> logout() async {
+    final authClient = ref.read(supabaseAuthClientProvider);
+    await authClient.signOut();
+    state = const AppAuthState(status: AuthStatus.unauthenticated);
+  }
+}
+
+final authProvider = NotifierProvider<AuthNotifier, AppAuthState>(
+  AuthNotifier.new,
+);

--- a/lib/features/auth/presentation/screens/login_screen.dart
+++ b/lib/features/auth/presentation/screens/login_screen.dart
@@ -3,7 +3,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
-import '../../../auth/presentation/providers/auth_notifier.dart';
+import '../../../auth/presentation/providers/auth_notifier.dart'
+    show authProvider, AppAuthState, AuthStatus;
 
 final connectionStatusProvider = FutureProvider<bool>((ref) async {
   try {
@@ -50,7 +51,7 @@ class LoginScreen extends ConsumerWidget {
             const SizedBox(height: 24),
             FilledButton(
               onPressed: () {
-                ref.read(authProvider.notifier).state = true;
+                ref.read(authProvider.notifier).state = const AppAuthState(status: AuthStatus.authenticated);
                 context.go('/songs');
               },
               child: const Text('Login (test)'),

--- a/lib/features/songs/presentation/screens/songs_screen.dart
+++ b/lib/features/songs/presentation/screens/songs_screen.dart
@@ -21,9 +21,11 @@ class SongsScreen extends ConsumerWidget {
         actions: [
           IconButton(
             icon: const Icon(Icons.logout),
-            onPressed: () {
-              ref.read(authProvider.notifier).state = false;
-              context.go('/login');
+            onPressed: () async {
+              await ref.read(authProvider.notifier).logout();
+              if (context.mounted) {
+                context.go('/login');
+              }
             },
           ),
         ],

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -613,6 +613,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
+  mocktail:
+    dependency: "direct dev"
+    description:
+      name: mocktail
+      sha256: "5e1bf53cc7baa8062a33b84424deb61513858ea05c601b8509e683815b5914aa"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.5"
   package_config:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,6 +39,9 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
+  # — Testing
+  mocktail: ^1.0.3
+
   # — Generadores de código (freezed + riverpod)
   build_runner: ^2.4.9
   freezed: ^2.5.2

--- a/test/auth_notifier_test.dart
+++ b/test/auth_notifier_test.dart
@@ -1,0 +1,113 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:ocari/features/auth/presentation/providers/auth_notifier.dart';
+import 'package:supabase_flutter/supabase_flutter.dart' as supabase;
+
+class MockGoTrueClient extends Mock implements supabase.GoTrueClient {}
+
+class FakeUser extends Fake implements supabase.User {}
+
+class FakeSession extends Fake implements supabase.Session {}
+
+void main() {
+  late MockGoTrueClient mockAuthClient;
+  late StreamController<supabase.AuthState> authEventController;
+
+  setUpAll(() {
+    registerFallbackValue(FakeUser());
+    registerFallbackValue(FakeSession());
+  });
+
+  setUp(() {
+    mockAuthClient = MockGoTrueClient();
+    authEventController = StreamController<supabase.AuthState>.broadcast();
+
+    when(() => mockAuthClient.onAuthStateChange)
+        .thenAnswer((_) => authEventController.stream);
+    when(() => mockAuthClient.currentSession).thenReturn(null);
+    when(() => mockAuthClient.signOut()).thenAnswer((_) async {});
+  });
+
+  tearDown(() {
+    authEventController.close();
+  });
+
+  group('AuthNotifier', () {
+    test('initial state is unauthenticated when no session', () {
+      final container = ProviderContainer(
+        overrides: [
+          supabaseAuthClientProvider.overrideWithValue(mockAuthClient),
+        ],
+      );
+
+      final authState = container.read(authProvider);
+
+      expect(authState.status, equals(AuthStatus.unauthenticated));
+      expect(authState.user, isNull);
+
+      container.dispose();
+    });
+
+    test('initial state is authenticated when session exists', () {
+      final mockUser = _createMockUser('user-123');
+      final mockSession = _createMockSession(mockUser);
+
+      when(() => mockAuthClient.currentSession).thenReturn(mockSession);
+
+      final container = ProviderContainer(
+        overrides: [
+          supabaseAuthClientProvider.overrideWithValue(mockAuthClient),
+        ],
+      );
+
+      final authState = container.read(authProvider);
+
+      expect(authState.status, equals(AuthStatus.authenticated));
+      expect(authState.user, equals(mockUser));
+
+      container.dispose();
+    });
+
+    test('logout calls signOut and updates state to unauthenticated', () async {
+      final container = ProviderContainer(
+        overrides: [
+          supabaseAuthClientProvider.overrideWithValue(mockAuthClient),
+        ],
+      );
+
+      expect(container.read(authProvider).status, equals(AuthStatus.unauthenticated));
+
+      await container.read(authProvider.notifier).logout();
+
+      verify(() => mockAuthClient.signOut()).called(1);
+
+      expect(container.read(authProvider).status, equals(AuthStatus.unauthenticated));
+
+      container.dispose();
+    });
+  });
+}
+
+supabase.User _createMockUser(String id) {
+  return supabase.User(
+    id: id,
+    appMetadata: {},
+    userMetadata: {},
+    aud: 'authenticated',
+    email: 'test@example.com',
+    createdAt: DateTime.now().toIso8601String(),
+  );
+}
+
+supabase.Session _createMockSession(supabase.User user) {
+  return supabase.Session(
+    accessToken: 'mock-token',
+    tokenType: 'Bearer',
+    expiresIn: 3600,
+    refreshToken: 'mock-refresh',
+    user: user,
+  );
+}


### PR DESCRIPTION
- Sesión persiste entre reinicios (supabase_flutter)
- AuthNotifier con Riverpod que expone estado real de sesión
- logout() llama a supabase.auth.signOut() y actualiza el estado
- Creado test en 3 casos: inicial sin sesión, con sesión y logout