### PR TITLE
Feat/31 songscreen list

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ git checkout -b feature/07-login-email
 
 ## Hoja de ruta
 
-### Sprint 0 — Fundación _(en progreso)_
+### Sprint 0 — Fundación
 
 - [x] Aplicación base Flutter inicializada
 - [x] Estructura de carpetas y arquitectura
@@ -129,7 +129,7 @@ git checkout -b feature/07-login-email
 - [x] Design system y componentes base
 - [x] CI/CD con GitHub Actions
 
-### Sprint 1 — Reproductor _(próximo)_
+### Sprint 1 — Reproductor _(en progreso)_
 
 - [x] Pantalla de lista de canciones
 - [ ] Reproductor con ocarina animada (CustomPainter)

--- a/lib/core/widgets/song_card.dart
+++ b/lib/core/widgets/song_card.dart
@@ -34,7 +34,7 @@ class SongCard extends StatelessWidget {
     return Opacity(
       opacity: isLocked ? 0.5 : 1,
       child: InkWell(
-        onTap: isLocked ? null : onTap,
+        onTap: onTap,
         borderRadius: AppRadius.borderRadiusLg,
         child: Container(
           padding: const EdgeInsets.symmetric(

--- a/lib/core/widgets/song_card.dart
+++ b/lib/core/widgets/song_card.dart
@@ -4,6 +4,8 @@ import 'package:ocari/features/songs/domain/models/difficulty.dart';
 import 'difficulty_badge.dart';
 
 class SongCard extends StatelessWidget {
+  static const double _lockedOpacity = 0.5;
+
   final String title;
   final Difficulty difficulty;
   final int durationSeconds;
@@ -32,7 +34,7 @@ class SongCard extends StatelessWidget {
     final colors = context.colors;
 
     return Opacity(
-      opacity: isLocked ? 0.5 : 1,
+      opacity: isLocked ? _lockedOpacity : 1,
       child: InkWell(
         onTap: onTap,
         borderRadius: AppRadius.borderRadiusLg,

--- a/lib/features/songs/presentation/screens/songs_screen.dart
+++ b/lib/features/songs/presentation/screens/songs_screen.dart
@@ -9,6 +9,8 @@ import 'package:ocari/features/songs/domain/models/difficulty.dart';
 import 'package:ocari/features/songs/domain/models/song.dart';
 import 'package:ocari/features/songs/presentation/providers/songs_provider.dart';
 
+const _iconSizeLg = 48.0;
+
 class SongsScreen extends ConsumerStatefulWidget {
   const SongsScreen({super.key});
 
@@ -37,7 +39,8 @@ class _SongsScreenState extends ConsumerState<SongsScreen> {
       }).toList();
     }
     if (_difficultyFilter != null) {
-      result = result.where((s) => s.difficulty == _difficultyFilter).toList();
+      result =
+          result.where((s) => s.difficulty == _difficultyFilter).toList();
     }
     return result;
   }
@@ -51,7 +54,7 @@ class _SongsScreenState extends ConsumerState<SongsScreen> {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Icon(Icons.lock_rounded, size: 48, color: colors.accent),
+            Icon(Icons.lock_rounded, size: _iconSizeLg, color: colors.accent),
             const SizedBox(height: AppSpacing.md),
             Text('Próximamente', style: context.textTheme.titleLarge),
             const SizedBox(height: AppSpacing.sm),
@@ -76,22 +79,78 @@ class _SongsScreenState extends ConsumerState<SongsScreen> {
   @override
   Widget build(BuildContext context) {
     final songsAsync = ref.watch(songsProvider);
+    final colors = context.colors;
 
     return OcariScaffold(
       title: 'Canciones',
       showBackButton: false,
       body: songsAsync.when(
         loading: () => const Center(child: CircularProgressIndicator()),
-        error: (err, _) => _ErrorView(
-          message: '$err',
-          onRetry: () => ref.read(songsProvider.notifier).refresh(),
+        error: (err, _) => Center(
+          child: Padding(
+            padding: const EdgeInsets.all(AppSpacing.lg),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(
+                  Icons.error_outline_rounded,
+                  size: _iconSizeLg,
+                  color: colors.error,
+                ),
+                const SizedBox(height: AppSpacing.md),
+                Text(
+                  'Error al cargar canciones',
+                  style: context.textTheme.titleMedium?.copyWith(
+                    color: colors.onBgLight,
+                  ),
+                ),
+                const SizedBox(height: AppSpacing.sm),
+                Text(
+                  '$err',
+                  style: AppTextStyles.caption(colors.textSecondary),
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: AppSpacing.lg),
+                FilledButton.icon(
+                  onPressed: () =>
+                      ref.read(songsProvider.notifier).refresh(),
+                  icon: const Icon(Icons.refresh_rounded),
+                  label: const Text('Reintentar'),
+                ),
+              ],
+            ),
+          ),
         ),
         data: (songs) {
           final filtered = _filteredSongs(songs);
+          final hasFilters = _searchController.text.isNotEmpty ||
+              _difficultyFilter != null;
 
           return Column(
             children: [
-              _Header(songCount: songs.length),
+              Padding(
+                padding: const EdgeInsets.fromLTRB(
+                  AppSpacing.md,
+                  AppSpacing.lg,
+                  AppSpacing.md,
+                  AppSpacing.xs,
+                ),
+                child: Row(
+                  children: [
+                    Text(
+                      'Canciones',
+                      style: context.textTheme.headlineMedium?.copyWith(
+                        color: colors.onBgLight,
+                      ),
+                    ),
+                    const Spacer(),
+                    Text(
+                      '${songs.length} ${songs.length == 1 ? 'canción' : 'canciones'}',
+                      style: AppTextStyles.body(colors.textSecondary),
+                    ),
+                  ],
+                ),
+              ),
               _SearchField(
                 controller: _searchController,
                 onChanged: (_) => setState(() {}),
@@ -102,9 +161,28 @@ class _SongsScreenState extends ConsumerState<SongsScreen> {
               ),
               Expanded(
                 child: filtered.isEmpty
-                    ? _EmptyState(
-                        hasFilters: _searchController.text.isNotEmpty ||
-                            _difficultyFilter != null,
+                    ? Center(
+                        child: Column(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Icon(
+                              hasFilters
+                                  ? Icons.search_off_rounded
+                                  : Icons.music_note_rounded,
+                              size: _iconSizeLg,
+                              color: colors.textSecondary,
+                            ),
+                            const SizedBox(height: AppSpacing.md),
+                            Text(
+                              hasFilters
+                                  ? 'No se encontraron canciones'
+                                  : 'No hay canciones disponibles',
+                              style: context.textTheme.titleMedium?.copyWith(
+                                color: colors.textSecondary,
+                              ),
+                            ),
+                          ],
+                        ),
                       )
                     : RefreshIndicator(
                         onRefresh: () =>
@@ -144,40 +222,6 @@ class _SongsScreenState extends ConsumerState<SongsScreen> {
             ],
           );
         },
-      ),
-    );
-  }
-}
-
-class _Header extends StatelessWidget {
-  final int songCount;
-
-  const _Header({required this.songCount});
-
-  @override
-  Widget build(BuildContext context) {
-    final colors = context.colors;
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(
-        AppSpacing.md,
-        AppSpacing.lg,
-        AppSpacing.md,
-        AppSpacing.xs,
-      ),
-      child: Row(
-        children: [
-          Text(
-            'Canciones',
-            style: context.textTheme.headlineMedium?.copyWith(
-              color: colors.onBgLight,
-            ),
-          ),
-          const Spacer(),
-          Text(
-            '$songCount ${songCount == 1 ? 'canción' : 'canciones'}',
-            style: AppTextStyles.body(colors.textSecondary),
-          ),
-        ],
       ),
     );
   }
@@ -247,6 +291,39 @@ class _DifficultyFilter extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colors = context.colors;
+
+    final chipData = <({
+      Difficulty? value,
+      String label,
+      Color selectedBg,
+      Color selectedFg,
+    })>[
+      (
+        value: null,
+        label: 'Todas',
+        selectedBg: colors.accent.withValues(alpha: 0.2),
+        selectedFg: colors.accent,
+      ),
+      (
+        value: Difficulty.easy,
+        label: 'Fácil',
+        selectedBg: colors.diffEasyBg,
+        selectedFg: colors.diffEasyText,
+      ),
+      (
+        value: Difficulty.medium,
+        label: 'Medio',
+        selectedBg: colors.diffMediumBg,
+        selectedFg: colors.diffMediumText,
+      ),
+      (
+        value: Difficulty.hard,
+        label: 'Difícil',
+        selectedBg: colors.diffHardBg,
+        selectedFg: colors.diffHardText,
+      ),
+    ];
+
     return Padding(
       padding: const EdgeInsets.symmetric(
         horizontal: AppSpacing.md,
@@ -255,161 +332,29 @@ class _DifficultyFilter extends StatelessWidget {
       child: SingleChildScrollView(
         scrollDirection: Axis.horizontal,
         child: Row(
-          children: [
-            _DifficultyChip(
-              label: 'Todas',
-              isSelected: selected == null,
-              backgroundColor: colors.surface,
-              selectedColor: colors.accent.withValues(alpha: 0.2),
-              textColor: colors.onBgLight,
-              selectedTextColor: colors.accent,
-              onSelected: (_) => onChanged(null),
-            ),
-            const SizedBox(width: AppSpacing.sm),
-            _DifficultyChip(
-              label: 'Fácil',
-              isSelected: selected == Difficulty.easy,
-              backgroundColor: colors.surface,
-              selectedColor: colors.diffEasyBg,
-              textColor: colors.onBgLight,
-              selectedTextColor: colors.diffEasyText,
-              onSelected: (_) => onChanged(Difficulty.easy),
-            ),
-            const SizedBox(width: AppSpacing.sm),
-            _DifficultyChip(
-              label: 'Medio',
-              isSelected: selected == Difficulty.medium,
-              backgroundColor: colors.surface,
-              selectedColor: colors.diffMediumBg,
-              textColor: colors.onBgLight,
-              selectedTextColor: colors.diffMediumText,
-              onSelected: (_) => onChanged(Difficulty.medium),
-            ),
-            const SizedBox(width: AppSpacing.sm),
-            _DifficultyChip(
-              label: 'Difícil',
-              isSelected: selected == Difficulty.hard,
-              backgroundColor: colors.surface,
-              selectedColor: colors.diffHardBg,
-              textColor: colors.onBgLight,
-              selectedTextColor: colors.diffHardText,
-              onSelected: (_) => onChanged(Difficulty.hard),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-class _DifficultyChip extends StatelessWidget {
-  final String label;
-  final bool isSelected;
-  final Color backgroundColor;
-  final Color selectedColor;
-  final Color textColor;
-  final Color selectedTextColor;
-  final ValueChanged<bool?> onSelected;
-
-  const _DifficultyChip({
-    required this.label,
-    required this.isSelected,
-    required this.backgroundColor,
-    required this.selectedColor,
-    required this.textColor,
-    required this.selectedTextColor,
-    required this.onSelected,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    return ChoiceChip(
-      label: Text(label),
-      selected: isSelected,
-      selectedColor: selectedColor,
-      backgroundColor: backgroundColor,
-      labelStyle: TextStyle(
-        color: isSelected ? selectedTextColor : textColor,
-        fontWeight: isSelected ? FontWeight.w600 : FontWeight.w400,
-      ),
-      onSelected: onSelected,
-      side: BorderSide.none,
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(100),
-      ),
-    );
-  }
-}
-
-class _ErrorView extends StatelessWidget {
-  final String message;
-  final VoidCallback onRetry;
-
-  const _ErrorView({required this.message, required this.onRetry});
-
-  @override
-  Widget build(BuildContext context) {
-    final colors = context.colors;
-    return Center(
-      child: Padding(
-        padding: const EdgeInsets.all(AppSpacing.lg),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Icon(Icons.error_outline_rounded, size: 48, color: colors.error),
-            const SizedBox(height: AppSpacing.md),
-            Text(
-              'Error al cargar canciones',
-              style: context.textTheme.titleMedium?.copyWith(
-                color: colors.onBgLight,
+          children: chipData.map((c) {
+            final isSelected = selected == c.value;
+            return Padding(
+              padding: const EdgeInsets.only(right: AppSpacing.sm),
+              child: ChoiceChip(
+                label: Text(c.label),
+                selected: isSelected,
+                selectedColor: c.selectedBg,
+                backgroundColor: colors.surface,
+                labelStyle: TextStyle(
+                  color: isSelected ? c.selectedFg : colors.onBgLight,
+                  fontWeight:
+                      isSelected ? FontWeight.w600 : FontWeight.w400,
+                ),
+                onSelected: (_) => onChanged(c.value),
+                side: BorderSide.none,
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(100),
+                ),
               ),
-            ),
-            const SizedBox(height: AppSpacing.sm),
-            Text(
-              message,
-              style: AppTextStyles.caption(colors.textSecondary),
-              textAlign: TextAlign.center,
-            ),
-            const SizedBox(height: AppSpacing.lg),
-            FilledButton.icon(
-              onPressed: onRetry,
-              icon: const Icon(Icons.refresh_rounded),
-              label: const Text('Reintentar'),
-            ),
-          ],
+            );
+          }).toList(),
         ),
-      ),
-    );
-  }
-}
-
-class _EmptyState extends StatelessWidget {
-  final bool hasFilters;
-
-  const _EmptyState({required this.hasFilters});
-
-  @override
-  Widget build(BuildContext context) {
-    final colors = context.colors;
-    return Center(
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Icon(
-            hasFilters ? Icons.search_off_rounded : Icons.music_note_rounded,
-            size: 48,
-            color: colors.textSecondary,
-          ),
-          const SizedBox(height: AppSpacing.md),
-          Text(
-            hasFilters
-                ? 'No se encontraron canciones'
-                : 'No hay canciones disponibles',
-            style: context.textTheme.titleMedium?.copyWith(
-              color: colors.textSecondary,
-            ),
-          ),
-        ],
       ),
     );
   }

--- a/lib/features/songs/presentation/screens/songs_screen.dart
+++ b/lib/features/songs/presentation/screens/songs_screen.dart
@@ -39,8 +39,7 @@ class _SongsScreenState extends ConsumerState<SongsScreen> {
       }).toList();
     }
     if (_difficultyFilter != null) {
-      result =
-          result.where((s) => s.difficulty == _difficultyFilter).toList();
+      result = result.where((s) => s.difficulty == _difficultyFilter).toList();
     }
     return result;
   }
@@ -112,8 +111,7 @@ class _SongsScreenState extends ConsumerState<SongsScreen> {
                 ),
                 const SizedBox(height: AppSpacing.lg),
                 FilledButton.icon(
-                  onPressed: () =>
-                      ref.read(songsProvider.notifier).refresh(),
+                  onPressed: () => ref.read(songsProvider.notifier).refresh(),
                   icon: const Icon(Icons.refresh_rounded),
                   label: const Text('Reintentar'),
                 ),
@@ -123,8 +121,8 @@ class _SongsScreenState extends ConsumerState<SongsScreen> {
         ),
         data: (songs) {
           final filtered = _filteredSongs(songs);
-          final hasFilters = _searchController.text.isNotEmpty ||
-              _difficultyFilter != null;
+          final hasFilters =
+              _searchController.text.isNotEmpty || _difficultyFilter != null;
 
           return Column(
             children: [
@@ -343,8 +341,7 @@ class _DifficultyFilter extends StatelessWidget {
                 backgroundColor: colors.surface,
                 labelStyle: TextStyle(
                   color: isSelected ? c.selectedFg : colors.onBgLight,
-                  fontWeight:
-                      isSelected ? FontWeight.w600 : FontWeight.w400,
+                  fontWeight: isSelected ? FontWeight.w600 : FontWeight.w400,
                 ),
                 onSelected: (_) => onChanged(c.value),
                 side: BorderSide.none,

--- a/lib/features/songs/presentation/screens/songs_screen.dart
+++ b/lib/features/songs/presentation/screens/songs_screen.dart
@@ -2,92 +2,414 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import 'package:ocari/core/theme/app_theme.dart';
 import 'package:ocari/core/widgets/ocari_scaffold.dart';
 import 'package:ocari/core/widgets/song_card.dart';
-import 'package:ocari/features/auth/presentation/providers/auth_notifier.dart';
+import 'package:ocari/features/songs/domain/models/difficulty.dart';
+import 'package:ocari/features/songs/domain/models/song.dart';
 import 'package:ocari/features/songs/presentation/providers/songs_provider.dart';
 
-class SongsScreen extends ConsumerWidget {
+class SongsScreen extends ConsumerStatefulWidget {
   const SongsScreen({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<SongsScreen> createState() => _SongsScreenState();
+}
+
+class _SongsScreenState extends ConsumerState<SongsScreen> {
+  final _searchController = TextEditingController();
+  Difficulty? _difficultyFilter;
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  List<Song> _filteredSongs(List<Song> songs) {
+    var result = songs;
+    final query = _searchController.text;
+    if (query.isNotEmpty) {
+      final lowerQuery = query.toLowerCase();
+      result = result.where((s) {
+        return s.title.toLowerCase().contains(lowerQuery) ||
+            s.artist.toLowerCase().contains(lowerQuery);
+      }).toList();
+    }
+    if (_difficultyFilter != null) {
+      result = result.where((s) => s.difficulty == _difficultyFilter).toList();
+    }
+    return result;
+  }
+
+  void _showPremiumComingSoon() {
+    final colors = context.colors;
+    showModalBottomSheet(
+      context: context,
+      builder: (ctx) => Padding(
+        padding: const EdgeInsets.all(AppSpacing.lg),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.lock_rounded, size: 48, color: colors.accent),
+            const SizedBox(height: AppSpacing.md),
+            Text('Próximamente', style: context.textTheme.titleLarge),
+            const SizedBox(height: AppSpacing.sm),
+            Text(
+              'Esta canción estará disponible pronto, la desarrolladora está a un paso de la locura.',
+              style: context.textTheme.bodyMedium?.copyWith(
+                color: colors.textSecondary,
+              ),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: AppSpacing.lg),
+            FilledButton(
+              onPressed: () => Navigator.of(ctx).pop(),
+              child: const Text('Entendido'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final songsAsync = ref.watch(songsProvider);
 
     return OcariScaffold(
-      title: 'Songs',
-      actions: [
-        IconButton(
-          icon: const Icon(Icons.logout),
-          onPressed: () async {
-            final confirmed = await showDialog<bool>(
-              context: context,
-              builder: (ctx) => AlertDialog(
-                title: const Text('Sign out'),
-                content: const Text('Are you sure you want to sign out?'),
-                actions: [
-                  TextButton(
-                      onPressed: () => Navigator.of(ctx).pop(false),
-                      child: const Text('Cancel')),
-                  TextButton(
-                      onPressed: () => Navigator.of(ctx).pop(true),
-                      child: const Text('Sign out')),
-                ],
-              ),
-            );
-            if (confirmed == true) {
-              await ref.read(authProvider.notifier).logout();
-              if (context.mounted) {
-                context.go('/login');
-              }
-            }
-          },
-        ),
-      ],
+      title: 'Canciones',
+      showBackButton: false,
       body: songsAsync.when(
         loading: () => const Center(child: CircularProgressIndicator()),
-        error: (err, _) => Center(child: Text('Failed to load songs: $err')),
+        error: (err, _) => _ErrorView(
+          message: '$err',
+          onRetry: () => ref.read(songsProvider.notifier).refresh(),
+        ),
         data: (songs) {
-          if (songs.isEmpty) {
-            return ListView(
-              children: [
-                SizedBox(height: MediaQuery.of(context).size.height * 0.3),
-                Center(
-                  child: Column(
-                    children: [
-                      Icon(Icons.music_note, size: 64, color: Theme.of(context).disabledColor),
-                      const SizedBox(height: 16),
-                      Text(
-                        'No songs available',
-                        style: Theme.of(context).textTheme.titleMedium,
-                      ),
-                    ],
-                  ),
-                ),
-              ],
-            );
-          }
+          final filtered = _filteredSongs(songs);
 
-          return RefreshIndicator(
-            onRefresh: () => ref.read(songsProvider.notifier).refresh(),
-            child: ListView(
-              padding: const EdgeInsets.all(16),
-              children: songs
-                  .map((song) => Padding(
-                        padding: const EdgeInsets.only(bottom: 8),
-                        child: SongCard(
-                          title: song.title,
-                          artist: song.artist,
-                          difficulty: song.difficulty,
-                          durationSeconds: song.durationSeconds,
-                          isLocked: song.isPremium,
-                          onTap: () => context.push('/player/${song.id}'),
+          return Column(
+            children: [
+              _Header(songCount: songs.length),
+              _SearchField(
+                controller: _searchController,
+                onChanged: (_) => setState(() {}),
+              ),
+              _DifficultyFilter(
+                selected: _difficultyFilter,
+                onChanged: (v) => setState(() => _difficultyFilter = v),
+              ),
+              Expanded(
+                child: filtered.isEmpty
+                    ? _EmptyState(
+                        hasFilters: _searchController.text.isNotEmpty ||
+                            _difficultyFilter != null,
+                      )
+                    : RefreshIndicator(
+                        onRefresh: () =>
+                            ref.read(songsProvider.notifier).refresh(),
+                        child: ListView.builder(
+                          padding: const EdgeInsets.only(
+                            left: AppSpacing.md,
+                            right: AppSpacing.md,
+                            bottom: AppSpacing.md,
+                          ),
+                          itemCount: filtered.length,
+                          itemBuilder: (context, index) {
+                            final song = filtered[index];
+                            return Padding(
+                              padding: const EdgeInsets.only(
+                                bottom: AppSpacing.sm,
+                              ),
+                              child: SongCard(
+                                title: song.title,
+                                artist: song.artist,
+                                difficulty: song.difficulty,
+                                durationSeconds: song.durationSeconds,
+                                isLocked: song.isPremium,
+                                onTap: () {
+                                  if (song.isPremium) {
+                                    _showPremiumComingSoon();
+                                  } else {
+                                    context.push('/player/${song.id}');
+                                  }
+                                },
+                              ),
+                            );
+                          },
                         ),
-                      ))
-                  .toList(),
-            ),
+                      ),
+              ),
+            ],
           );
         },
+      ),
+    );
+  }
+}
+
+class _Header extends StatelessWidget {
+  final int songCount;
+
+  const _Header({required this.songCount});
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(
+        AppSpacing.md,
+        AppSpacing.lg,
+        AppSpacing.md,
+        AppSpacing.xs,
+      ),
+      child: Row(
+        children: [
+          Text(
+            'Canciones',
+            style: context.textTheme.headlineMedium?.copyWith(
+              color: colors.onBgLight,
+            ),
+          ),
+          const Spacer(),
+          Text(
+            '$songCount ${songCount == 1 ? 'canción' : 'canciones'}',
+            style: AppTextStyles.body(colors.textSecondary),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SearchField extends StatelessWidget {
+  final TextEditingController controller;
+  final ValueChanged<String> onChanged;
+
+  const _SearchField({required this.controller, required this.onChanged});
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return Padding(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.md,
+        vertical: AppSpacing.sm,
+      ),
+      child: TextField(
+        controller: controller,
+        onChanged: onChanged,
+        style: AppTextStyles.body(colors.onBgLight),
+        decoration: InputDecoration(
+          hintText: 'Buscar canciones...',
+          hintStyle: AppTextStyles.body(colors.textSecondary),
+          prefixIcon: Icon(Icons.search_rounded, color: colors.textSecondary),
+          suffixIcon: controller.text.isNotEmpty
+              ? IconButton(
+                  icon: Icon(Icons.close_rounded, color: colors.textSecondary),
+                  onPressed: () {
+                    controller.clear();
+                    onChanged('');
+                  },
+                )
+              : null,
+          filled: true,
+          fillColor: colors.surface,
+          border: const OutlineInputBorder(
+            borderRadius: AppRadius.borderRadiusLg,
+            borderSide: BorderSide.none,
+          ),
+          enabledBorder: const OutlineInputBorder(
+            borderRadius: AppRadius.borderRadiusLg,
+            borderSide: BorderSide.none,
+          ),
+          focusedBorder: OutlineInputBorder(
+            borderRadius: AppRadius.borderRadiusLg,
+            borderSide: BorderSide(color: colors.accent),
+          ),
+          contentPadding: const EdgeInsets.symmetric(
+            horizontal: AppSpacing.md,
+            vertical: AppSpacing.md,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _DifficultyFilter extends StatelessWidget {
+  final Difficulty? selected;
+  final ValueChanged<Difficulty?> onChanged;
+
+  const _DifficultyFilter({required this.selected, required this.onChanged});
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return Padding(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.md,
+        vertical: AppSpacing.xs,
+      ),
+      child: SingleChildScrollView(
+        scrollDirection: Axis.horizontal,
+        child: Row(
+          children: [
+            _DifficultyChip(
+              label: 'Todas',
+              isSelected: selected == null,
+              backgroundColor: colors.surface,
+              selectedColor: colors.accent.withValues(alpha: 0.2),
+              textColor: colors.onBgLight,
+              selectedTextColor: colors.accent,
+              onSelected: (_) => onChanged(null),
+            ),
+            const SizedBox(width: AppSpacing.sm),
+            _DifficultyChip(
+              label: 'Fácil',
+              isSelected: selected == Difficulty.easy,
+              backgroundColor: colors.surface,
+              selectedColor: colors.diffEasyBg,
+              textColor: colors.onBgLight,
+              selectedTextColor: colors.diffEasyText,
+              onSelected: (_) => onChanged(Difficulty.easy),
+            ),
+            const SizedBox(width: AppSpacing.sm),
+            _DifficultyChip(
+              label: 'Medio',
+              isSelected: selected == Difficulty.medium,
+              backgroundColor: colors.surface,
+              selectedColor: colors.diffMediumBg,
+              textColor: colors.onBgLight,
+              selectedTextColor: colors.diffMediumText,
+              onSelected: (_) => onChanged(Difficulty.medium),
+            ),
+            const SizedBox(width: AppSpacing.sm),
+            _DifficultyChip(
+              label: 'Difícil',
+              isSelected: selected == Difficulty.hard,
+              backgroundColor: colors.surface,
+              selectedColor: colors.diffHardBg,
+              textColor: colors.onBgLight,
+              selectedTextColor: colors.diffHardText,
+              onSelected: (_) => onChanged(Difficulty.hard),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _DifficultyChip extends StatelessWidget {
+  final String label;
+  final bool isSelected;
+  final Color backgroundColor;
+  final Color selectedColor;
+  final Color textColor;
+  final Color selectedTextColor;
+  final ValueChanged<bool?> onSelected;
+
+  const _DifficultyChip({
+    required this.label,
+    required this.isSelected,
+    required this.backgroundColor,
+    required this.selectedColor,
+    required this.textColor,
+    required this.selectedTextColor,
+    required this.onSelected,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return ChoiceChip(
+      label: Text(label),
+      selected: isSelected,
+      selectedColor: selectedColor,
+      backgroundColor: backgroundColor,
+      labelStyle: TextStyle(
+        color: isSelected ? selectedTextColor : textColor,
+        fontWeight: isSelected ? FontWeight.w600 : FontWeight.w400,
+      ),
+      onSelected: onSelected,
+      side: BorderSide.none,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(100),
+      ),
+    );
+  }
+}
+
+class _ErrorView extends StatelessWidget {
+  final String message;
+  final VoidCallback onRetry;
+
+  const _ErrorView({required this.message, required this.onRetry});
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(AppSpacing.lg),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.error_outline_rounded, size: 48, color: colors.error),
+            const SizedBox(height: AppSpacing.md),
+            Text(
+              'Error al cargar canciones',
+              style: context.textTheme.titleMedium?.copyWith(
+                color: colors.onBgLight,
+              ),
+            ),
+            const SizedBox(height: AppSpacing.sm),
+            Text(
+              message,
+              style: AppTextStyles.caption(colors.textSecondary),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: AppSpacing.lg),
+            FilledButton.icon(
+              onPressed: onRetry,
+              icon: const Icon(Icons.refresh_rounded),
+              label: const Text('Reintentar'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _EmptyState extends StatelessWidget {
+  final bool hasFilters;
+
+  const _EmptyState({required this.hasFilters});
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(
+            hasFilters ? Icons.search_off_rounded : Icons.music_note_rounded,
+            size: 48,
+            color: colors.textSecondary,
+          ),
+          const SizedBox(height: AppSpacing.md),
+          Text(
+            hasFilters
+                ? 'No se encontraron canciones'
+                : 'No hay canciones disponibles',
+            style: context.textTheme.titleMedium?.copyWith(
+              color: colors.textSecondary,
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/test/widgets/song_card_test.dart
+++ b/test/widgets/song_card_test.dart
@@ -142,7 +142,7 @@ void main() {
       expect(tapped, isTrue);
     });
 
-    testWidgets('does not call onTap when isLocked is true', (tester) async {
+    testWidgets('calls onTap even when isLocked is true', (tester) async {
       bool tapped = false;
       await tester.pumpWidget(
         createWidgetUnderTest(
@@ -157,7 +157,7 @@ void main() {
       );
 
       await tester.tap(find.byType(SongCard));
-      expect(tapped, isFalse);
+      expect(tapped, isTrue);
     });
 
     testWidgets('shows difficulty badge for unlocked songs', (tester) async {


### PR DESCRIPTION
## Qué hace este PR

Implementa la pantalla principal de catálogo de canciones (`SongsScreen`) con búsqueda local en tiempo real, filtros por dificultad, manejo de canciones premium (bottom sheet "Próximamente") y estados completo de carga/error/vacío. Refactoriza `SongCard` para delegar la decisión de bloqueo al padre y limpia el código según auditoría de diseño.

## Issue relacionada

Closes #31 

## Tipo de cambio

- [x] feat — nueva funcionalidad
- [ ] fix — corrección de bug
- [x] refactor — cambio de código sin nueva funcionalidad
- [ ] chore — tareas de mantenimiento (deps, CI, etc.)
- [ ] docs — documentación

## Checklist

- [x] El código compila sin errores (`flutter build`)
- [x] No hay warnings en `flutter analyze`
- [ ] Los tests pasan (`flutter test`)
- [x] Probé en simulador/dispositivo físico
