### PR TITLE
Featute/36 completescreen

### DIFF
--- a/lib/features/player/domain/models/player_state.dart
+++ b/lib/features/player/domain/models/player_state.dart
@@ -18,6 +18,8 @@ class PlayerState with _$PlayerState {
     required bool isPlaying,
     required double speed,
     required Duration position,
+    @Default(false) bool showCompletionSheet,
+    @Default(0) int playCount,
   }) = _PlayerState;
 
   factory PlayerState.fromJson(Map<String, dynamic> json) =>

--- a/lib/features/player/domain/models/player_state.freezed.dart
+++ b/lib/features/player/domain/models/player_state.freezed.dart
@@ -27,6 +27,8 @@ mixin _$PlayerState {
   bool get isPlaying => throw _privateConstructorUsedError;
   double get speed => throw _privateConstructorUsedError;
   Duration get position => throw _privateConstructorUsedError;
+  bool get showCompletionSheet => throw _privateConstructorUsedError;
+  int get playCount => throw _privateConstructorUsedError;
 
   /// Serializes this PlayerState to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
@@ -51,7 +53,9 @@ abstract class $PlayerStateCopyWith<$Res> {
       int currentNoteIndex,
       bool isPlaying,
       double speed,
-      Duration position});
+      Duration position,
+      bool showCompletionSheet,
+      int playCount});
 
   $SongCopyWith<$Res> get song;
 }
@@ -78,6 +82,8 @@ class _$PlayerStateCopyWithImpl<$Res, $Val extends PlayerState>
     Object? isPlaying = null,
     Object? speed = null,
     Object? position = null,
+    Object? showCompletionSheet = null,
+    Object? playCount = null,
   }) {
     return _then(_value.copyWith(
       song: null == song
@@ -108,6 +114,14 @@ class _$PlayerStateCopyWithImpl<$Res, $Val extends PlayerState>
           ? _value.position
           : position // ignore: cast_nullable_to_non_nullable
               as Duration,
+      showCompletionSheet: null == showCompletionSheet
+          ? _value.showCompletionSheet
+          : showCompletionSheet // ignore: cast_nullable_to_non_nullable
+              as bool,
+      playCount: null == playCount
+          ? _value.playCount
+          : playCount // ignore: cast_nullable_to_non_nullable
+              as int,
     ) as $Val);
   }
 
@@ -137,7 +151,9 @@ abstract class _$$PlayerStateImplCopyWith<$Res>
       int currentNoteIndex,
       bool isPlaying,
       double speed,
-      Duration position});
+      Duration position,
+      bool showCompletionSheet,
+      int playCount});
 
   @override
   $SongCopyWith<$Res> get song;
@@ -163,6 +179,8 @@ class __$$PlayerStateImplCopyWithImpl<$Res>
     Object? isPlaying = null,
     Object? speed = null,
     Object? position = null,
+    Object? showCompletionSheet = null,
+    Object? playCount = null,
   }) {
     return _then(_$PlayerStateImpl(
       song: null == song
@@ -193,6 +211,14 @@ class __$$PlayerStateImplCopyWithImpl<$Res>
           ? _value.position
           : position // ignore: cast_nullable_to_non_nullable
               as Duration,
+      showCompletionSheet: null == showCompletionSheet
+          ? _value.showCompletionSheet
+          : showCompletionSheet // ignore: cast_nullable_to_non_nullable
+              as bool,
+      playCount: null == playCount
+          ? _value.playCount
+          : playCount // ignore: cast_nullable_to_non_nullable
+              as int,
     ));
   }
 }
@@ -207,7 +233,9 @@ class _$PlayerStateImpl implements _PlayerState {
       required this.currentNoteIndex,
       required this.isPlaying,
       required this.speed,
-      required this.position})
+      required this.position,
+      this.showCompletionSheet = false,
+      this.playCount = 0})
       : _notes = notes;
 
   factory _$PlayerStateImpl.fromJson(Map<String, dynamic> json) =>
@@ -234,10 +262,16 @@ class _$PlayerStateImpl implements _PlayerState {
   final double speed;
   @override
   final Duration position;
+  @override
+  @JsonKey()
+  final bool showCompletionSheet;
+  @override
+  @JsonKey()
+  final int playCount;
 
   @override
   String toString() {
-    return 'PlayerState(song: $song, notes: $notes, isAudioReady: $isAudioReady, currentNoteIndex: $currentNoteIndex, isPlaying: $isPlaying, speed: $speed, position: $position)';
+    return 'PlayerState(song: $song, notes: $notes, isAudioReady: $isAudioReady, currentNoteIndex: $currentNoteIndex, isPlaying: $isPlaying, speed: $speed, position: $position, showCompletionSheet: $showCompletionSheet, playCount: $playCount)';
   }
 
   @override
@@ -255,7 +289,11 @@ class _$PlayerStateImpl implements _PlayerState {
                 other.isPlaying == isPlaying) &&
             (identical(other.speed, speed) || other.speed == speed) &&
             (identical(other.position, position) ||
-                other.position == position));
+                other.position == position) &&
+            (identical(other.showCompletionSheet, showCompletionSheet) ||
+                other.showCompletionSheet == showCompletionSheet) &&
+            (identical(other.playCount, playCount) ||
+                other.playCount == playCount));
   }
 
   @JsonKey(includeFromJson: false, includeToJson: false)
@@ -268,7 +306,9 @@ class _$PlayerStateImpl implements _PlayerState {
       currentNoteIndex,
       isPlaying,
       speed,
-      position);
+      position,
+      showCompletionSheet,
+      playCount);
 
   /// Create a copy of PlayerState
   /// with the given fields replaced by the non-null parameter values.
@@ -294,7 +334,9 @@ abstract class _PlayerState implements PlayerState {
       required final int currentNoteIndex,
       required final bool isPlaying,
       required final double speed,
-      required final Duration position}) = _$PlayerStateImpl;
+      required final Duration position,
+      final bool showCompletionSheet,
+      final int playCount}) = _$PlayerStateImpl;
 
   factory _PlayerState.fromJson(Map<String, dynamic> json) =
       _$PlayerStateImpl.fromJson;
@@ -313,6 +355,10 @@ abstract class _PlayerState implements PlayerState {
   double get speed;
   @override
   Duration get position;
+  @override
+  bool get showCompletionSheet;
+  @override
+  int get playCount;
 
   /// Create a copy of PlayerState
   /// with the given fields replaced by the non-null parameter values.

--- a/lib/features/player/domain/models/player_state.g.dart
+++ b/lib/features/player/domain/models/player_state.g.dart
@@ -17,6 +17,8 @@ _$PlayerStateImpl _$$PlayerStateImplFromJson(Map<String, dynamic> json) =>
       isPlaying: json['isPlaying'] as bool,
       speed: (json['speed'] as num).toDouble(),
       position: Duration(microseconds: (json['position'] as num).toInt()),
+      showCompletionSheet: json['showCompletionSheet'] as bool? ?? false,
+      playCount: (json['playCount'] as num?)?.toInt() ?? 0,
     );
 
 Map<String, dynamic> _$$PlayerStateImplToJson(_$PlayerStateImpl instance) =>
@@ -28,4 +30,6 @@ Map<String, dynamic> _$$PlayerStateImplToJson(_$PlayerStateImpl instance) =>
       'isPlaying': instance.isPlaying,
       'speed': instance.speed,
       'position': instance.position.inMicroseconds,
+      'showCompletionSheet': instance.showCompletionSheet,
+      'playCount': instance.playCount,
     };

--- a/lib/features/player/presentation/providers/player_notifier.dart
+++ b/lib/features/player/presentation/providers/player_notifier.dart
@@ -53,7 +53,22 @@ class PlayerNotifier extends Notifier<PlayerState> {
       );
 
   Future<void> initialize(Song song, List<SongNote> notes) async {
-    if (_currentSongId == song.id && _audioReady) return;
+    if (_currentSongId == song.id && _audioReady) {
+      _completionHandled = false;
+      await _player!.seek(Duration.zero);
+      await _player!.pause();
+      await _player!.setSpeed(1.0);
+      state = state.copyWith(
+        position: Duration.zero,
+        currentNoteIndex: 0,
+        isPlaying: false,
+        speed: 1.0,
+        showCompletionSheet: false,
+        playCount: 0,
+        isAudioReady: true,
+      );
+      return;
+    }
     _currentSongId = song.id;
     _completionHandled = false;
 

--- a/lib/features/player/presentation/providers/player_notifier.dart
+++ b/lib/features/player/presentation/providers/player_notifier.dart
@@ -4,8 +4,10 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:just_audio/just_audio.dart' hide PlayerState;
 
+import 'package:ocari/features/auth/presentation/providers/auth_notifier.dart';
 import 'package:ocari/features/player/data/player_cache.dart';
 import 'package:ocari/features/player/domain/models/player_state.dart';
+import 'package:ocari/features/progress/presentation/providers/progress_providers.dart';
 import 'package:ocari/features/songs/domain/models/difficulty.dart';
 import 'package:ocari/features/songs/domain/models/song.dart';
 import 'package:ocari/features/songs/domain/models/song_note.dart';
@@ -20,6 +22,7 @@ class PlayerNotifier extends Notifier<PlayerState> {
   List<SongNote> _notes = [];
   String? _currentSongId;
   bool _audioReady = false;
+  bool _completionHandled = false;
 
   bool get isAudioReady => _audioReady;
 
@@ -45,11 +48,14 @@ class PlayerNotifier extends Notifier<PlayerState> {
         isPlaying: false,
         speed: 1.0,
         position: Duration.zero,
+        showCompletionSheet: false,
+        playCount: 0,
       );
 
   Future<void> initialize(Song song, List<SongNote> notes) async {
     if (_currentSongId == song.id && _audioReady) return;
     _currentSongId = song.id;
+    _completionHandled = false;
 
     _playerStateSub?.cancel();
     _positionSub?.cancel();
@@ -62,6 +68,13 @@ class PlayerNotifier extends Notifier<PlayerState> {
     _playerStateSub = _player!.playerStateStream.listen((ps) {
       if (_currentSongId != song.id) return;
       state = state.copyWith(isPlaying: ps.playing);
+
+      if (ps.processingState == ProcessingState.completed &&
+          state.isAudioReady &&
+          !_completionHandled) {
+        _completionHandled = true;
+        _handleSongCompletion();
+      }
     });
 
     _positionSub = _player!.positionStream.listen((pos) {
@@ -77,6 +90,8 @@ class PlayerNotifier extends Notifier<PlayerState> {
       isPlaying: false,
       speed: 1.0,
       position: Duration.zero,
+      showCompletionSheet: false,
+      playCount: 0,
     );
 
     await _setupAudioSource(song);
@@ -189,6 +204,39 @@ class PlayerNotifier extends Notifier<PlayerState> {
     state = state.copyWith(position: duration, isPlaying: false);
     if (_notes.isNotEmpty) {
       state = state.copyWith(currentNoteIndex: _notes.length - 1);
+    }
+  }
+
+  Future<void> restart() async {
+    if (!canPlay) return;
+    _completionHandled = false;
+    await _player!.seek(Duration.zero);
+    await _player!.play();
+    state = state.copyWith(
+      position: Duration.zero,
+      currentNoteIndex: 0,
+      isPlaying: true,
+      showCompletionSheet: false,
+    );
+  }
+
+  Future<void> _handleSongCompletion() async {
+    try {
+      final authState = ref.read(authProvider);
+      final userId = authState.user?.id;
+      if (userId == null) return;
+
+      final repo = ref.read(userSongProgressRepositoryProvider);
+      final progress = await repo.recordCompletion(
+        userId: userId,
+        songId: state.song.id,
+      );
+      state = state.copyWith(
+        playCount: progress.playCount,
+        showCompletionSheet: true,
+      );
+    } catch (e) {
+      debugPrint('PlayerNotifier: failed to record song completion: $e');
     }
   }
 

--- a/lib/features/player/presentation/screens/player_screen.dart
+++ b/lib/features/player/presentation/screens/player_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
 import 'package:ocari/core/theme/app_theme.dart';
 import 'package:ocari/core/theme/note_colors.dart';
@@ -9,6 +10,7 @@ import 'package:ocari/core/widgets/ocarina_canvas.dart';
 import 'package:ocari/core/widgets/ocari_scaffold.dart';
 import 'package:ocari/features/player/domain/models/player_state.dart';
 import 'package:ocari/features/player/presentation/providers/player_notifier.dart';
+import 'package:ocari/features/player/presentation/widgets/song_completed_sheet.dart';
 import 'package:ocari/features/songs/domain/models/song.dart';
 import 'package:ocari/features/songs/domain/models/song_note.dart';
 import 'package:ocari/features/songs/presentation/providers/songs_provider.dart';
@@ -48,6 +50,22 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
     ref.listen(songByIdProvider(widget.songId), (_, next) {
       final song = next.valueOrNull;
       if (song != null) _initIfReady(song, notifier);
+    });
+
+    ref.listen(playerNotifierProvider, (prev, next) {
+      if (next.showCompletionSheet && !(prev?.showCompletionSheet ?? false)) {
+        showSongCompletedSheet(
+          context,
+          songTitle: next.song.title,
+          playCount: next.playCount,
+          onPlayAgain: () {
+            ref.read(playerNotifierProvider.notifier).restart();
+          },
+          onGoToCatalog: () {
+            context.pop();
+          },
+        );
+      }
     });
 
     return songAsync.when(

--- a/lib/features/player/presentation/widgets/song_completed_sheet.dart
+++ b/lib/features/player/presentation/widgets/song_completed_sheet.dart
@@ -41,8 +41,8 @@ void showSongCompletedSheet(
   final colors = context.colors;
   final msg = _completionMessage(playCount);
   final countText = playCount == 1
-      ? 'Has tocado esta canción 1 vez'
-      : 'Has tocado esta canción $playCount veces';
+      ? 'Has tocado esta canción 1 vez.'
+      : 'Has tocado esta canción $playCount veces.';
 
   showModalBottomSheet(
     context: context,
@@ -64,6 +64,7 @@ void showSongCompletedSheet(
                   fontWeight: FontWeight.w600,
                   color: colors.onBgLight,
                 ),
+                textAlign: TextAlign.center,
               ),
               const SizedBox(height: AppSpacing.sm),
               Text(
@@ -73,6 +74,7 @@ void showSongCompletedSheet(
                   fontWeight: FontWeight.w500,
                   color: colors.accent,
                 ),
+                textAlign: TextAlign.center,
               ),
               const SizedBox(height: AppSpacing.sm),
               Text(
@@ -91,6 +93,7 @@ void showSongCompletedSheet(
                   color: colors.textSecondary,
                   fontStyle: FontStyle.italic,
                 ),
+                textAlign: TextAlign.center,
               ),
               const SizedBox(height: AppSpacing.lg),
               SizedBox(

--- a/lib/features/player/presentation/widgets/song_completed_sheet.dart
+++ b/lib/features/player/presentation/widgets/song_completed_sheet.dart
@@ -25,7 +25,7 @@ void showSongCompletedSheet(
             mainAxisSize: MainAxisSize.min,
             children: [
               Text(
-                'Cancion completada',
+                'Canción completada',
                 style: TextStyle(
                   fontSize: 22,
                   fontWeight: FontWeight.w600,
@@ -44,8 +44,8 @@ void showSongCompletedSheet(
               const SizedBox(height: AppSpacing.md),
               Text(
                 playCount == 1
-                    ? 'Has tocado esta cancion 1 vez'
-                    : 'Has tocado esta cancion $playCount veces',
+                    ? 'Has tocado esta canción 1 vez'
+                    : 'Has tocado esta canción $playCount veces',
                 style: TextStyle(
                   fontSize: 14,
                   color: colors.textSecondary,
@@ -71,7 +71,7 @@ void showSongCompletedSheet(
                     onGoToCatalog();
                   },
                   child: Text(
-                    'Volver al catalogo',
+                    'Volver al catálogo',
                     style: TextStyle(color: colors.textSecondary),
                   ),
                 ),

--- a/lib/features/player/presentation/widgets/song_completed_sheet.dart
+++ b/lib/features/player/presentation/widgets/song_completed_sheet.dart
@@ -2,6 +2,35 @@ import 'package:flutter/material.dart';
 
 import 'package:ocari/core/theme/app_theme.dart';
 
+({String title, String subtitle}) _completionMessage(int playCount) {
+  return switch (playCount) {
+    1 => (
+        title: '¡Primera interpretación!',
+        subtitle: 'Toda gran melodía comienza con una sola nota.',
+      ),
+    2 || 3 => (
+        title: 'Ya estás tomando ritmo',
+        subtitle: 'Cada repetición fortalece tu memoria musical.',
+      ),
+    4 || 5 || 6 => (
+        title: 'La melodía empieza a quedarse contigo',
+        subtitle: 'Los movimientos de tus dedos ya son más naturales.',
+      ),
+    7 || 8 || 9 => (
+        title: 'Casi un maestro',
+        subtitle: 'La práctica constante es el secreto de todo músico.',
+      ),
+    10 || 11 || 12 => (
+        title: 'Ya conoces esta canción bastante bien',
+        subtitle: 'Ahora puedes concentrarte en tu fluidez.',
+      ),
+    _ => (
+        title: 'Canción dominada',
+        subtitle: 'Esta melodía ya forma parte de tu repertorio.',
+      ),
+  };
+}
+
 void showSongCompletedSheet(
   BuildContext context, {
   required String songTitle,
@@ -10,6 +39,10 @@ void showSongCompletedSheet(
   required VoidCallback onGoToCatalog,
 }) {
   final colors = context.colors;
+  final msg = _completionMessage(playCount);
+  final countText = playCount == 1
+      ? 'Has tocado esta canción 1 vez'
+      : 'Has tocado esta canción $playCount veces';
 
   showModalBottomSheet(
     context: context,
@@ -25,7 +58,7 @@ void showSongCompletedSheet(
             mainAxisSize: MainAxisSize.min,
             children: [
               Text(
-                'Canción completada',
+                msg.title,
                 style: TextStyle(
                   fontSize: 22,
                   fontWeight: FontWeight.w600,
@@ -41,14 +74,22 @@ void showSongCompletedSheet(
                   color: colors.accent,
                 ),
               ),
-              const SizedBox(height: AppSpacing.md),
+              const SizedBox(height: AppSpacing.sm),
               Text(
-                playCount == 1
-                    ? 'Has tocado esta canción 1 vez'
-                    : 'Has tocado esta canción $playCount veces',
+                msg.subtitle,
                 style: TextStyle(
                   fontSize: 14,
                   color: colors.textSecondary,
+                ),
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: AppSpacing.sm),
+              Text(
+                countText,
+                style: TextStyle(
+                  fontSize: 13,
+                  color: colors.textSecondary,
+                  fontStyle: FontStyle.italic,
                 ),
               ),
               const SizedBox(height: AppSpacing.lg),

--- a/lib/features/player/presentation/widgets/song_completed_sheet.dart
+++ b/lib/features/player/presentation/widgets/song_completed_sheet.dart
@@ -1,0 +1,85 @@
+import 'package:flutter/material.dart';
+
+import 'package:ocari/core/theme/app_theme.dart';
+
+void showSongCompletedSheet(
+  BuildContext context, {
+  required String songTitle,
+  required int playCount,
+  required VoidCallback onPlayAgain,
+  required VoidCallback onGoToCatalog,
+}) {
+  final colors = context.colors;
+
+  showModalBottomSheet(
+    context: context,
+    backgroundColor: colors.surface,
+    shape: const RoundedRectangleBorder(
+      borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+    ),
+    builder: (ctx) {
+      return SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(AppSpacing.lg),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                'Cancion completada',
+                style: TextStyle(
+                  fontSize: 22,
+                  fontWeight: FontWeight.w600,
+                  color: colors.onBgLight,
+                ),
+              ),
+              const SizedBox(height: AppSpacing.sm),
+              Text(
+                songTitle,
+                style: TextStyle(
+                  fontSize: 18,
+                  fontWeight: FontWeight.w500,
+                  color: colors.accent,
+                ),
+              ),
+              const SizedBox(height: AppSpacing.md),
+              Text(
+                playCount == 1
+                    ? 'Has tocado esta cancion 1 vez'
+                    : 'Has tocado esta cancion $playCount veces',
+                style: TextStyle(
+                  fontSize: 14,
+                  color: colors.textSecondary,
+                ),
+              ),
+              const SizedBox(height: AppSpacing.lg),
+              SizedBox(
+                width: double.infinity,
+                child: FilledButton(
+                  onPressed: () {
+                    Navigator.of(ctx).pop();
+                    onPlayAgain();
+                  },
+                  child: const Text('Tocar de nuevo'),
+                ),
+              ),
+              const SizedBox(height: AppSpacing.sm),
+              SizedBox(
+                width: double.infinity,
+                child: TextButton(
+                  onPressed: () {
+                    Navigator.of(ctx).pop();
+                    onGoToCatalog();
+                  },
+                  child: Text(
+                    'Volver al catalogo',
+                    style: TextStyle(color: colors.textSecondary),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      );
+    },
+  );
+}

--- a/lib/features/progress/data/repositories/supabase_user_song_progress_repository.dart
+++ b/lib/features/progress/data/repositories/supabase_user_song_progress_repository.dart
@@ -1,0 +1,29 @@
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import 'package:ocari/features/progress/domain/models/user_song_progress.dart';
+import 'package:ocari/features/progress/domain/repositories/user_song_progress_repository.dart';
+
+class SupabaseUserSongProgressRepository
+    implements UserSongProgressRepository {
+  final SupabaseClient _client;
+
+  SupabaseUserSongProgressRepository(this._client);
+
+  @override
+  Future<UserSongProgress> recordCompletion({
+    required String userId,
+    required String songId,
+  }) async {
+    final response = await _client.rpc('record_song_completion', params: {
+      'p_user_id': userId,
+      'p_song_id': songId,
+    });
+
+    final row = response as List<dynamic>? ?? [response];
+    if (row.isEmpty) {
+      throw Exception('record_song_completion returned no data');
+    }
+
+    return UserSongProgress.fromJson(row.first as Map<String, dynamic>);
+  }
+}

--- a/lib/features/progress/domain/models/user_song_progress.dart
+++ b/lib/features/progress/domain/models/user_song_progress.dart
@@ -1,0 +1,22 @@
+// ignore_for_file: invalid_annotation_target
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'user_song_progress.freezed.dart';
+part 'user_song_progress.g.dart';
+
+@freezed
+class UserSongProgress with _$UserSongProgress {
+  const factory UserSongProgress({
+    String? id,
+    @JsonKey(name: 'user_id') required String userId,
+    @JsonKey(name: 'song_id') required String songId,
+    @JsonKey(name: 'play_count') required int playCount,
+    required bool completed,
+    @JsonKey(name: 'last_played_at') required DateTime lastPlayedAt,
+    @JsonKey(name: 'created_at') DateTime? createdAt,
+  }) = _UserSongProgress;
+
+  factory UserSongProgress.fromJson(Map<String, dynamic> json) =>
+      _$UserSongProgressFromJson(json);
+}

--- a/lib/features/progress/domain/models/user_song_progress.freezed.dart
+++ b/lib/features/progress/domain/models/user_song_progress.freezed.dart
@@ -1,0 +1,310 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'user_song_progress.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+UserSongProgress _$UserSongProgressFromJson(Map<String, dynamic> json) {
+  return _UserSongProgress.fromJson(json);
+}
+
+/// @nodoc
+mixin _$UserSongProgress {
+  String? get id => throw _privateConstructorUsedError;
+  @JsonKey(name: 'user_id')
+  String get userId => throw _privateConstructorUsedError;
+  @JsonKey(name: 'song_id')
+  String get songId => throw _privateConstructorUsedError;
+  @JsonKey(name: 'play_count')
+  int get playCount => throw _privateConstructorUsedError;
+  bool get completed => throw _privateConstructorUsedError;
+  @JsonKey(name: 'last_played_at')
+  DateTime get lastPlayedAt => throw _privateConstructorUsedError;
+  @JsonKey(name: 'created_at')
+  DateTime? get createdAt => throw _privateConstructorUsedError;
+
+  /// Serializes this UserSongProgress to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+
+  /// Create a copy of UserSongProgress
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $UserSongProgressCopyWith<UserSongProgress> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $UserSongProgressCopyWith<$Res> {
+  factory $UserSongProgressCopyWith(
+          UserSongProgress value, $Res Function(UserSongProgress) then) =
+      _$UserSongProgressCopyWithImpl<$Res, UserSongProgress>;
+  @useResult
+  $Res call(
+      {String? id,
+      @JsonKey(name: 'user_id') String userId,
+      @JsonKey(name: 'song_id') String songId,
+      @JsonKey(name: 'play_count') int playCount,
+      bool completed,
+      @JsonKey(name: 'last_played_at') DateTime lastPlayedAt,
+      @JsonKey(name: 'created_at') DateTime? createdAt});
+}
+
+/// @nodoc
+class _$UserSongProgressCopyWithImpl<$Res, $Val extends UserSongProgress>
+    implements $UserSongProgressCopyWith<$Res> {
+  _$UserSongProgressCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of UserSongProgress
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = freezed,
+    Object? userId = null,
+    Object? songId = null,
+    Object? playCount = null,
+    Object? completed = null,
+    Object? lastPlayedAt = null,
+    Object? createdAt = freezed,
+  }) {
+    return _then(_value.copyWith(
+      id: freezed == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String?,
+      userId: null == userId
+          ? _value.userId
+          : userId // ignore: cast_nullable_to_non_nullable
+              as String,
+      songId: null == songId
+          ? _value.songId
+          : songId // ignore: cast_nullable_to_non_nullable
+              as String,
+      playCount: null == playCount
+          ? _value.playCount
+          : playCount // ignore: cast_nullable_to_non_nullable
+              as int,
+      completed: null == completed
+          ? _value.completed
+          : completed // ignore: cast_nullable_to_non_nullable
+              as bool,
+      lastPlayedAt: null == lastPlayedAt
+          ? _value.lastPlayedAt
+          : lastPlayedAt // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+      createdAt: freezed == createdAt
+          ? _value.createdAt
+          : createdAt // ignore: cast_nullable_to_non_nullable
+              as DateTime?,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$UserSongProgressImplCopyWith<$Res>
+    implements $UserSongProgressCopyWith<$Res> {
+  factory _$$UserSongProgressImplCopyWith(_$UserSongProgressImpl value,
+          $Res Function(_$UserSongProgressImpl) then) =
+      __$$UserSongProgressImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {String? id,
+      @JsonKey(name: 'user_id') String userId,
+      @JsonKey(name: 'song_id') String songId,
+      @JsonKey(name: 'play_count') int playCount,
+      bool completed,
+      @JsonKey(name: 'last_played_at') DateTime lastPlayedAt,
+      @JsonKey(name: 'created_at') DateTime? createdAt});
+}
+
+/// @nodoc
+class __$$UserSongProgressImplCopyWithImpl<$Res>
+    extends _$UserSongProgressCopyWithImpl<$Res, _$UserSongProgressImpl>
+    implements _$$UserSongProgressImplCopyWith<$Res> {
+  __$$UserSongProgressImplCopyWithImpl(_$UserSongProgressImpl _value,
+      $Res Function(_$UserSongProgressImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of UserSongProgress
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = freezed,
+    Object? userId = null,
+    Object? songId = null,
+    Object? playCount = null,
+    Object? completed = null,
+    Object? lastPlayedAt = null,
+    Object? createdAt = freezed,
+  }) {
+    return _then(_$UserSongProgressImpl(
+      id: freezed == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String?,
+      userId: null == userId
+          ? _value.userId
+          : userId // ignore: cast_nullable_to_non_nullable
+              as String,
+      songId: null == songId
+          ? _value.songId
+          : songId // ignore: cast_nullable_to_non_nullable
+              as String,
+      playCount: null == playCount
+          ? _value.playCount
+          : playCount // ignore: cast_nullable_to_non_nullable
+              as int,
+      completed: null == completed
+          ? _value.completed
+          : completed // ignore: cast_nullable_to_non_nullable
+              as bool,
+      lastPlayedAt: null == lastPlayedAt
+          ? _value.lastPlayedAt
+          : lastPlayedAt // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+      createdAt: freezed == createdAt
+          ? _value.createdAt
+          : createdAt // ignore: cast_nullable_to_non_nullable
+              as DateTime?,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$UserSongProgressImpl implements _UserSongProgress {
+  const _$UserSongProgressImpl(
+      {this.id,
+      @JsonKey(name: 'user_id') required this.userId,
+      @JsonKey(name: 'song_id') required this.songId,
+      @JsonKey(name: 'play_count') required this.playCount,
+      required this.completed,
+      @JsonKey(name: 'last_played_at') required this.lastPlayedAt,
+      @JsonKey(name: 'created_at') this.createdAt});
+
+  factory _$UserSongProgressImpl.fromJson(Map<String, dynamic> json) =>
+      _$$UserSongProgressImplFromJson(json);
+
+  @override
+  final String? id;
+  @override
+  @JsonKey(name: 'user_id')
+  final String userId;
+  @override
+  @JsonKey(name: 'song_id')
+  final String songId;
+  @override
+  @JsonKey(name: 'play_count')
+  final int playCount;
+  @override
+  final bool completed;
+  @override
+  @JsonKey(name: 'last_played_at')
+  final DateTime lastPlayedAt;
+  @override
+  @JsonKey(name: 'created_at')
+  final DateTime? createdAt;
+
+  @override
+  String toString() {
+    return 'UserSongProgress(id: $id, userId: $userId, songId: $songId, playCount: $playCount, completed: $completed, lastPlayedAt: $lastPlayedAt, createdAt: $createdAt)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$UserSongProgressImpl &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.userId, userId) || other.userId == userId) &&
+            (identical(other.songId, songId) || other.songId == songId) &&
+            (identical(other.playCount, playCount) ||
+                other.playCount == playCount) &&
+            (identical(other.completed, completed) ||
+                other.completed == completed) &&
+            (identical(other.lastPlayedAt, lastPlayedAt) ||
+                other.lastPlayedAt == lastPlayedAt) &&
+            (identical(other.createdAt, createdAt) ||
+                other.createdAt == createdAt));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, id, userId, songId, playCount,
+      completed, lastPlayedAt, createdAt);
+
+  /// Create a copy of UserSongProgress
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$UserSongProgressImplCopyWith<_$UserSongProgressImpl> get copyWith =>
+      __$$UserSongProgressImplCopyWithImpl<_$UserSongProgressImpl>(
+          this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$UserSongProgressImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _UserSongProgress implements UserSongProgress {
+  const factory _UserSongProgress(
+          {final String? id,
+          @JsonKey(name: 'user_id') required final String userId,
+          @JsonKey(name: 'song_id') required final String songId,
+          @JsonKey(name: 'play_count') required final int playCount,
+          required final bool completed,
+          @JsonKey(name: 'last_played_at') required final DateTime lastPlayedAt,
+          @JsonKey(name: 'created_at') final DateTime? createdAt}) =
+      _$UserSongProgressImpl;
+
+  factory _UserSongProgress.fromJson(Map<String, dynamic> json) =
+      _$UserSongProgressImpl.fromJson;
+
+  @override
+  String? get id;
+  @override
+  @JsonKey(name: 'user_id')
+  String get userId;
+  @override
+  @JsonKey(name: 'song_id')
+  String get songId;
+  @override
+  @JsonKey(name: 'play_count')
+  int get playCount;
+  @override
+  bool get completed;
+  @override
+  @JsonKey(name: 'last_played_at')
+  DateTime get lastPlayedAt;
+  @override
+  @JsonKey(name: 'created_at')
+  DateTime? get createdAt;
+
+  /// Create a copy of UserSongProgress
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$UserSongProgressImplCopyWith<_$UserSongProgressImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/features/progress/domain/models/user_song_progress.g.dart
+++ b/lib/features/progress/domain/models/user_song_progress.g.dart
@@ -1,0 +1,33 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'user_song_progress.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$UserSongProgressImpl _$$UserSongProgressImplFromJson(
+        Map<String, dynamic> json) =>
+    _$UserSongProgressImpl(
+      id: json['id'] as String?,
+      userId: json['user_id'] as String,
+      songId: json['song_id'] as String,
+      playCount: (json['play_count'] as num).toInt(),
+      completed: json['completed'] as bool,
+      lastPlayedAt: DateTime.parse(json['last_played_at'] as String),
+      createdAt: json['created_at'] == null
+          ? null
+          : DateTime.parse(json['created_at'] as String),
+    );
+
+Map<String, dynamic> _$$UserSongProgressImplToJson(
+        _$UserSongProgressImpl instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'user_id': instance.userId,
+      'song_id': instance.songId,
+      'play_count': instance.playCount,
+      'completed': instance.completed,
+      'last_played_at': instance.lastPlayedAt.toIso8601String(),
+      'created_at': instance.createdAt?.toIso8601String(),
+    };

--- a/lib/features/progress/domain/repositories/user_song_progress_repository.dart
+++ b/lib/features/progress/domain/repositories/user_song_progress_repository.dart
@@ -1,0 +1,8 @@
+import 'package:ocari/features/progress/domain/models/user_song_progress.dart';
+
+abstract class UserSongProgressRepository {
+  Future<UserSongProgress> recordCompletion({
+    required String userId,
+    required String songId,
+  });
+}

--- a/lib/features/progress/presentation/providers/progress_providers.dart
+++ b/lib/features/progress/presentation/providers/progress_providers.dart
@@ -1,0 +1,10 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:ocari/features/progress/data/repositories/supabase_user_song_progress_repository.dart';
+import 'package:ocari/features/progress/domain/repositories/user_song_progress_repository.dart';
+import 'package:ocari/features/songs/presentation/providers/songs_provider.dart';
+
+final userSongProgressRepositoryProvider =
+    Provider<UserSongProgressRepository>((ref) {
+  return SupabaseUserSongProgressRepository(ref.watch(supabaseClientProvider));
+});


### PR DESCRIPTION
## Qué hace este PR

Implementa `SongCompletedSheet`, un bottom sheet que aparece automáticamente al terminar una canción. Muestra mensajes personalizados según el número de veces que se ha tocado, el nombre de la canción, las estadísticas de reproducción y botones para tocar de nuevo o volver al catálogo. Además, registra el progreso en Supabase mediante una función RPC que incrementa `play_count`, marca `completed = true` y actualiza `last_played_at`.

<img width="410" height="740" alt="Captura de pantalla 2026-06-16 a la(s) 12 13 32 p m" src="https://github.com/user-attachments/assets/157e9ddc-138d-4401-9266-6d42d86cd86d" />


## Issue relacionada

Closes #36 

## Tipo de cambio

- [x] feat — nueva funcionalidad
- [ ] fix — corrección de bug
- [ ] refactor — cambio de código sin nueva funcionalidad
- [ ] chore — tareas de mantenimiento (deps, CI, etc.)
- [ ] docs — documentación

## Checklist

- [x] El código compila sin errores (`flutter build`)
- [x] No hay warnings en `flutter analyze`
- [x] Los tests pasan (`flutter test`)
- [x] Probé en simulador/dispositivo físico
