### PR TITLE
test(player): add notifier and screen tests

### DIFF
--- a/test/player_notifier_test.dart
+++ b/test/player_notifier_test.dart
@@ -1,0 +1,201 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:ocari/core/services/audio_service.dart';
+import 'package:ocari/features/player/presentation/providers/player_notifier.dart';
+import 'package:ocari/features/songs/domain/models/difficulty.dart';
+import 'package:ocari/features/songs/domain/models/song.dart';
+import 'package:ocari/features/songs/domain/models/song_note.dart';
+
+class MockAudioService extends Mock implements AudioService {}
+
+class _Fixtures {
+  static const noteC4 = SongNote(
+    note: 'C4',
+    top: [1, 0, 0, 0],
+    bot: [0, 0, 0, 0],
+    sub: [0, 0],
+    middle: [0, 0],
+    timestampMs: 0,
+    durationMs: 1000,
+    noteValue: 'quarter',
+  );
+  static const noteD4 = SongNote(
+    note: 'D4',
+    top: [1, 1, 0, 0],
+    bot: [0, 0, 0, 0],
+    sub: [0, 0],
+    middle: [0, 0],
+    timestampMs: 1000,
+    durationMs: 1000,
+    noteValue: 'quarter',
+  );
+  static const noteE4 = SongNote(
+    note: 'E4',
+    top: [1, 1, 1, 0],
+    bot: [0, 0, 0, 0],
+    sub: [0, 0],
+    middle: [0, 0],
+    timestampMs: 2000,
+    durationMs: 1000,
+    noteValue: 'quarter',
+  );
+  static const song = Song(
+    id: 'test-song',
+    title: 'Test',
+    difficulty: Difficulty.easy,
+    durationSeconds: 30,
+    audioPath: 'assets/audio/test.mp3',
+  );
+  static const notes = [noteC4, noteD4, noteE4];
+}
+
+void main() {
+  late MockAudioService mockAudioService;
+
+  setUpAll(() {
+    registerFallbackValue(Duration.zero);
+  });
+
+  setUp(() {
+    mockAudioService = MockAudioService();
+    when(() => mockAudioService.positionStream)
+        .thenAnswer((_) => const Stream.empty());
+    when(() => mockAudioService.playingStream)
+        .thenAnswer((_) => const Stream.empty());
+    when(() => mockAudioService.completionStream)
+        .thenAnswer((_) => const Stream.empty());
+    when(() => mockAudioService.load(any())).thenAnswer((_) async {});
+    when(() => mockAudioService.play()).thenAnswer((_) async {});
+    when(() => mockAudioService.pause()).thenAnswer((_) async {});
+    when(() => mockAudioService.seek(any())).thenAnswer((_) async {});
+    when(() => mockAudioService.setSpeed(any())).thenAnswer((_) async {});
+    when(() => mockAudioService.duration).thenReturn(Duration.zero);
+    when(() => mockAudioService.isPlaying).thenReturn(false);
+  });
+
+  group('PlayerNotifier initial state', () {
+    test('has empty song and default values', () {
+      final container = ProviderContainer(
+        overrides: [
+          audioServiceProvider.overrideWithValue(mockAudioService),
+        ],
+      );
+      addTearDown(() => container.dispose());
+
+      final state = container.read(playerNotifierProvider);
+      expect(state.song.id, '');
+      expect(state.notes, isEmpty);
+      expect(state.currentNoteIndex, 0);
+      expect(state.isPlaying, false);
+      expect(state.speed, 1.0);
+      expect(state.position, Duration.zero);
+      expect(state.isAudioReady, false);
+      expect(state.showCompletionSheet, false);
+      expect(state.playCount, 0);
+    });
+  });
+
+  group('PlayerNotifier onAudioPosition', () {
+    test('updates currentNoteIndex when position advances', () async {
+      final container = ProviderContainer(
+        overrides: [
+          audioServiceProvider.overrideWithValue(mockAudioService),
+        ],
+      );
+      addTearDown(() => container.dispose());
+
+      final notifier = container.read(playerNotifierProvider.notifier);
+      await notifier.initialize(_Fixtures.song, _Fixtures.notes);
+
+      notifier.onAudioPosition(0);
+      expect(
+        container.read(playerNotifierProvider).currentNoteIndex,
+        0,
+        reason: 'at 0ms should be on first note',
+      );
+
+      notifier.onAudioPosition(500);
+      expect(
+        container.read(playerNotifierProvider).currentNoteIndex,
+        0,
+        reason: 'at 500ms should still be on first note',
+      );
+
+      notifier.onAudioPosition(1500);
+      expect(
+        container.read(playerNotifierProvider).currentNoteIndex,
+        1,
+        reason: 'at 1500ms should be on second note',
+      );
+
+      notifier.onAudioPosition(2500);
+      expect(
+        container.read(playerNotifierProvider).currentNoteIndex,
+        2,
+        reason: 'at 2500ms should be on third note',
+      );
+    });
+
+    test('stays at last note when position exceeds all timestamps', () async {
+      final container = ProviderContainer(
+        overrides: [
+          audioServiceProvider.overrideWithValue(mockAudioService),
+        ],
+      );
+      addTearDown(() => container.dispose());
+
+      final notifier = container.read(playerNotifierProvider.notifier);
+      await notifier.initialize(_Fixtures.song, _Fixtures.notes);
+
+      notifier.onAudioPosition(10000);
+      expect(
+        container.read(playerNotifierProvider).currentNoteIndex,
+        2,
+        reason: 'beyond last note should clamp to last index',
+      );
+    });
+
+    test('updates position in state', () async {
+      final container = ProviderContainer(
+        overrides: [
+          audioServiceProvider.overrideWithValue(mockAudioService),
+        ],
+      );
+      addTearDown(() => container.dispose());
+
+      final notifier = container.read(playerNotifierProvider.notifier);
+      await notifier.initialize(_Fixtures.song, _Fixtures.notes);
+
+      notifier.onAudioPosition(1500);
+      expect(
+        container.read(playerNotifierProvider).position,
+        const Duration(milliseconds: 1500),
+      );
+    });
+  });
+
+  group('PlayerNotifier setSpeed', () {
+    test('updates PlayerState.speed and delegates to AudioService', () async {
+      final container = ProviderContainer(
+        overrides: [
+          audioServiceProvider.overrideWithValue(mockAudioService),
+        ],
+      );
+      addTearDown(() => container.dispose());
+
+      final notifier = container.read(playerNotifierProvider.notifier);
+      await notifier.initialize(_Fixtures.song, _Fixtures.notes);
+
+      await notifier.setSpeed(0.5);
+      expect(container.read(playerNotifierProvider).speed, 0.5);
+      verify(() => mockAudioService.setSpeed(0.5)).called(1);
+
+      await notifier.setSpeed(1.0);
+      expect(container.read(playerNotifierProvider).speed, 1.0);
+      verify(() => mockAudioService.setSpeed(1.0)).called(1);
+    });
+  });
+}

--- a/test/widgets/ocarina_canvas_test.dart
+++ b/test/widgets/ocarina_canvas_test.dart
@@ -185,5 +185,38 @@ void main() {
       final textStyle = textWidget.style;
       expect(textStyle?.color, isNot(equals(NoteColors.forNote('D5'))));
     });
+
+    testWidgets('displays updated note name when note changes', (tester) async {
+      const noteA5 = SongNote(
+        note: 'A5',
+        top: [0, 0, 0, 0],
+        bot: [0, 0, 0, 0],
+        sub: [0, 0],
+        middle: [0, 0],
+        timestampMs: 0,
+        durationMs: 500,
+        noteValue: 'quarter',
+      );
+      const noteD5 = SongNote(
+        note: 'D5',
+        top: [1, 1, 1, 0],
+        bot: [0, 0, 0, 0],
+        sub: [1, 1],
+        middle: [0, 0],
+        timestampMs: 1000,
+        durationMs: 500,
+        noteValue: 'quarter',
+      );
+
+      await tester.pumpWidget(createLightWidget(note: noteA5));
+      expect(find.text('A5'), findsOneWidget);
+      expect(find.text('D5'), findsNothing);
+
+      await tester.pumpWidget(createLightWidget(note: noteD5));
+      await tester.pumpAndSettle();
+
+      expect(find.text('D5'), findsOneWidget);
+      expect(find.text('A5'), findsNothing);
+    });
   });
 }

--- a/test/widgets/player_screen_test.dart
+++ b/test/widgets/player_screen_test.dart
@@ -1,0 +1,171 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:ocari/core/services/audio_service.dart';
+import 'package:ocari/core/theme/app_theme.dart';
+import 'package:ocari/features/player/presentation/screens/player_screen.dart';
+import 'package:ocari/features/songs/domain/models/difficulty.dart';
+import 'package:ocari/features/songs/domain/models/song.dart';
+import 'package:ocari/features/songs/presentation/providers/songs_provider.dart';
+
+class MockAudioService extends Mock implements AudioService {}
+
+const _testSong = Song(
+  id: 'test-song',
+  title: 'Test Song',
+  difficulty: Difficulty.easy,
+  durationSeconds: 30,
+  notesJson: {
+    'notes': [
+      {
+        'note': 'C4',
+        'top': [1, 0, 0, 0],
+        'bot': [0, 0, 0, 0],
+        'sub': [0, 0],
+        'middle': [0, 0],
+        'timestamp_ms': 0,
+        'duration_ms': 1000,
+        'note_value': 'quarter',
+      },
+      {
+        'note': 'D4',
+        'top': [1, 1, 0, 0],
+        'bot': [0, 0, 0, 0],
+        'sub': [0, 0],
+        'middle': [0, 0],
+        'timestamp_ms': 1000,
+        'duration_ms': 1000,
+        'note_value': 'quarter',
+      },
+    ],
+  },
+);
+
+Widget createTestWidget({
+  required MockAudioService mockAudioService,
+  required Song song,
+}) {
+  return ProviderScope(
+    overrides: [
+      songByIdProvider(song.id).overrideWith(
+        (ref) async => song,
+      ),
+      audioServiceProvider.overrideWithValue(mockAudioService),
+    ],
+    child: MaterialApp(
+      theme: AppTheme.lightTheme,
+      home: PlayerScreen(songId: song.id),
+    ),
+  );
+}
+
+void main() {
+  late MockAudioService mockAudioService;
+  late StreamController<bool> playingController;
+
+  setUpAll(() {
+    registerFallbackValue(Duration.zero);
+  });
+
+  setUp(() {
+    playingController = StreamController<bool>.broadcast();
+    mockAudioService = MockAudioService();
+
+    when(() => mockAudioService.positionStream)
+        .thenAnswer((_) => const Stream.empty());
+    when(() => mockAudioService.playingStream)
+        .thenAnswer((_) => playingController.stream);
+    when(() => mockAudioService.completionStream)
+        .thenAnswer((_) => const Stream.empty());
+    when(() => mockAudioService.load(any())).thenAnswer((_) async {});
+    when(() => mockAudioService.play()).thenAnswer((_) async {});
+    when(() => mockAudioService.pause()).thenAnswer((_) async {});
+    when(() => mockAudioService.seek(any())).thenAnswer((_) async {});
+    when(() => mockAudioService.setSpeed(any())).thenAnswer((_) async {});
+    when(() => mockAudioService.duration).thenReturn(Duration.zero);
+    when(() => mockAudioService.isPlaying).thenReturn(false);
+  });
+
+  tearDown(() {
+    playingController.close();
+  });
+
+  group('PlayerScreen', () {
+    testWidgets('renders song title and player elements for valid songId',
+        (tester) async {
+      addTearDown(() {
+        tester.view.resetPhysicalSize();
+        tester.view.resetDevicePixelRatio();
+      });
+      tester.view.physicalSize = const Size(411, 891);
+      tester.view.devicePixelRatio = 1.0;
+      await tester.pumpWidget(createTestWidget(
+        mockAudioService: mockAudioService,
+        song: _testSong,
+      ));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Test Song'), findsWidgets);
+      expect(find.byIcon(Icons.play_circle_filled_rounded), findsOneWidget);
+      expect(find.byType(Slider), findsOneWidget);
+      expect(find.text('×1'), findsOneWidget);
+    });
+
+    testWidgets('play button toggles to pause when audio plays',
+        (tester) async {
+      addTearDown(() {
+        tester.view.resetPhysicalSize();
+        tester.view.resetDevicePixelRatio();
+      });
+      tester.view.physicalSize = const Size(411, 891);
+      tester.view.devicePixelRatio = 1.0;
+      await tester.pumpWidget(createTestWidget(
+        mockAudioService: mockAudioService,
+        song: _testSong,
+      ));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byIcon(Icons.play_circle_filled_rounded));
+      await tester.pump();
+
+      verify(() => mockAudioService.play()).called(1);
+
+      playingController.add(true);
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.pause_circle_filled_rounded), findsOneWidget);
+    });
+
+    testWidgets('pause button toggles back to play when audio pauses',
+        (tester) async {
+      addTearDown(() {
+        tester.view.resetPhysicalSize();
+        tester.view.resetDevicePixelRatio();
+      });
+      tester.view.physicalSize = const Size(411, 891);
+      tester.view.devicePixelRatio = 1.0;
+      await tester.pumpWidget(createTestWidget(
+        mockAudioService: mockAudioService,
+        song: _testSong,
+      ));
+      await tester.pumpAndSettle();
+
+      playingController.add(true);
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byIcon(Icons.pause_circle_filled_rounded));
+      await tester.pump();
+
+      verify(() => mockAudioService.pause()).called(1);
+
+      playingController.add(false);
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.play_circle_filled_rounded), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Qué hace este PR

Agrega cobertura de tests para los componentes críticos del reproductor: `OcarinaCanvas`, `PlayerNotifier` y `PlayerScreen`. También expone `audioPositionProvider` como `StreamProvider<int>` público y extrae el método `onAudioPosition(int ms)` para mejorar legibilidad y testabilidad.

## Issue relacionada

Closes #40 

## Tipo de cambio

- [x] feat — nueva funcionalidad
- [ ] fix — corrección de bug
- [x] refactor — cambio de código sin nueva funcionalidad
- [ ] chore — tareas de mantenimiento (deps, CI, etc.)
- [ ] docs — documentación

## Checklist

- [x] El código compila sin errores (`flutter build`)
- [x] No hay warnings en `flutter analyze`
- [x] Los tests pasan (`flutter test`)
- [ ] Probé en simulador/dispositivo físico
